### PR TITLE
Changes to work with Katello

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -18,6 +18,7 @@ class tsm::config inherits tsm {
     owner  => 'root',
     group  => 'root',
     mode   => '0644',
+    notify => Service[$::tsm::service_name],
   }
 
   concat::fragment { 'dsm_sys_template':

--- a/manifests/service/redhat.pp
+++ b/manifests/service/redhat.pp
@@ -30,7 +30,6 @@ class tsm::service::redhat {
     enable     => $::tsm::service_enable,
     hasstatus  => true,
     hasrestart => true,
-    subscribe  => File[$::tsm::config],
   }
 
   File[$::tsm::service_script] -> Service[$::tsm::service_name]


### PR DESCRIPTION
This change removes the subscription to the configuration file from the service as during creation it's resource might not exist.

Moving the service restart to a notify on the file itself to trigger the restart.