### PR TITLE
Starting the service with puppet does only work on debian if it is tr…

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Storage Manager (TSM) client on the following operating systems:
 * Oracle Linux 5/6/7
 * Scientific Linux 5/6/7
 * Solaris 10/11
-* Debian 7
+* Debian 6/7
 
 ##Setup
 
@@ -149,7 +149,7 @@ The module has been tested on:
 * RedHat Enterprise Linux 5/6
 * Solaris 10 i386/sparc
 * Solaris 11 i386/sparc
-* Debian 7
+* Debian 6/7
 
 ##Development
 

--- a/files/dsmsched.debian
+++ b/files/dsmsched.debian
@@ -51,11 +51,12 @@ case "$1" in
                 echo "dsmc is running with PID: "$pid
         else
                 echo "dsmc is not running "
+                exit 1
         fi
         ;;
   *)
         echo "Usage: dsmcsched {start|stop|restart|status}"
         exit 1
-esac
+esac 
 
 exit 0


### PR DESCRIPTION
…iggered with refreshonly. Puppet requires that the status of a service exits with !0. In order to make starting the service work, the dsmsched.debian is changed.

Tested the module on Debian 6 and it works. Changed the README