### PR TITLE
Added support for AIX and tested it on version 7.1!

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Storage Manager (TSM) client on the following operating systems:
 * Scientific Linux 5/6/7
 * Solaris 10/11
 * Debian 6/7
+* AIX 7.1
 
 ##Setup
 
@@ -79,6 +80,16 @@ so you have to translate them with pkgtrans:
 and copy them to your HTTP download location. You are going to need two
 download locations: one for sparc and one for i386 (see params.pp for
 an example).
+
+For AIX the application is shipped by IBM as LPP in BFF format. The 
+package can be installed using the 'nim' (default) or 'aix' provider.
+Installing from a NIM repository, the variable 'package_uri' must 
+contain a valid lpp_source in order to make the installation work.
+This module will then install 'tivoli.tsm.client.ba.64bit.base' and its 
+requesite software.
+
+By setting the 'service_manage' variable to true, 'dsmc sched' will be
+added as a subsystem definition to the subsystem object class in AIX.
 
 ###Beginning with tsm
 
@@ -150,6 +161,7 @@ The module has been tested on:
 * Solaris 10 i386/sparc
 * Solaris 11 i386/sparc
 * Debian 6/7
+* AIX 7.1
 
 ##Development
 

--- a/files/InclExcl.AIX
+++ b/files/InclExcl.AIX
@@ -1,0 +1,12 @@
+exclude /var/run/.../*
+exclude /var/spool/.../*
+exclude /.../core
+exclude /.../tmp/.../*
+exclude.dir /mnt
+exclude.dir /proc
+exclude /cdrom/*
+exclude /cdrom/.../*
+exclude /unix/
+exclude.dir /unix/
+
+

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -13,13 +13,13 @@
 class tsm::config inherits tsm {
 
   concat { $::tsm::config:
-    ensure => present,
+    ensure  => present,
     replace => $::tsm::config_replace,
-    owner  => 'root',
-    group  => 'root',
-    mode   => '0644',
+    owner   => 'root',
+    group   => $::tsm::rootgroup,
+    mode    => '0644',
   }
-
+  
   concat::fragment { 'dsm_sys_template':
     target  => $::tsm::config,
     content => template($::tsm::config_template),
@@ -29,7 +29,7 @@ class tsm::config inherits tsm {
   file { "${::tsm::config}.local":
     ensure => file,
     owner  => 'root',
-    group  => 'root',
+    group  => $::tsm::rootgroup,
     mode   => '0644',
   } ->
   concat::fragment { 'dsm_sys_local':
@@ -42,7 +42,7 @@ class tsm::config inherits tsm {
     ensure  => file,
     replace => $::tsm::inclexcl_replace,
     owner   => 'root',
-    group   => 'root',
+    group   => $::tsm::rootgroup,
     mode    => '0644',
     source  => $::tsm::inclexcl_source,
   }
@@ -51,7 +51,7 @@ class tsm::config inherits tsm {
     ensure  => file,
     replace => $::tsm::inclexcl_replace,
     owner   => 'root',
-    group   => 'root',
+    group   => $::tsm::rootgroup,
     mode    => '0644',
   }
 
@@ -60,7 +60,7 @@ class tsm::config inherits tsm {
       ensure  => file,
       replace => $::tsm::config_replace,
       owner   => 'root',
-      group   => 'root',
+      group   => $::tsm::rootgroup,
       mode    => '0644',
       content => template($::tsm::config_opt_template),
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -173,6 +173,8 @@ class tsm (
   $packages                = $::tsm::params::packages,
   $package_adminfile       = $::tsm::params::package_adminfile,
   $package_uri             = $::tsm::params::package_uri,
+  $package_provider        = $::tsm::params::package_provider,
+  $package_source          = $::tsm::params::package_source,
   $service_manage          = $::tsm::params::service_manage,
   $service_ensure          = $::tsm::params::service_ensure,
   $service_name            = $::tsm::params::service_name,
@@ -187,6 +189,7 @@ class tsm (
   $config_opt              = $::tsm::params::config_opt,
   $config_replace          = $::tsm::params::config_replace,
   $config_template         = $::tsm::params::config_template,
+  $rootgroup               = $::tsm::params::rootgroup,
   $inclexcl                = $::tsm::params::inclexcl,
   $inclexcl_local          = $::tsm::params::inclexcl_local,
   $inclexcl_replace        = $::tsm::params::inclexcl_replace,
@@ -205,9 +208,6 @@ class tsm (
   validate_bool($service_manage)
   validate_string($service_ensure)
   validate_string($service_name)
-  validate_string($service_manifest_source)
-  validate_absolute_path($service_script)
-  validate_string($service_script_source)
   validate_absolute_path($tsm_pwd)
   validate_string($initial_password)
   validate_bool($set_initial_password)
@@ -218,11 +218,31 @@ class tsm (
   validate_absolute_path($inclexcl)
   validate_absolute_path($inclexcl_local)
   validate_string($inclexcl_source)
+  validate_string($rootgroup)
 
   case $::osfamily {
     solaris: {
       validate_absolute_path($package_adminfile)
       validate_absolute_path($service_manifest)
+      validate_string($service_manifest_source)
+      validate_absolute_path($service_script)
+      validate_string($service_script_source)
+      validate_string($package_provider)
+      validate_string($package_source)
+    }
+    redhat: {
+      validate_string($service_manifest_source)
+      validate_absolute_path($service_script)
+      validate_string($service_script_source)
+    }
+    debian: {
+      validate_string($service_manifest_source)
+      validate_absolute_path($service_script)
+      validate_string($service_script_source)
+    }
+    AIX: {
+      validate_string($package_provider)
+      validate_string($package_source)
     }
     default: {
       # do nothing

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -16,6 +16,8 @@ class tsm::install inherits tsm {
     ensure    => $::tsm::package_ensure,
     uri       => $::tsm::package_uri,
     adminfile => $::tsm::package_adminfile,
+    provider  => $::tsm::package_provider,
+    source    => $::tsm::package_source,
   }
 
   case $::osfamily {

--- a/manifests/installpkg.pp
+++ b/manifests/installpkg.pp
@@ -30,10 +30,14 @@ define tsm::installpkg (
   $ensure    = 'installed',
   $adminfile = '/dev/null',
   $uri        = '',
+  $provider   = undef,
+  $source     = undef,
   ) {
   validate_string($ensure)
   validate_absolute_path($adminfile)
   validate_string($uri)
+  validate_string($provider)
+  validate_string($source)
 
   package { $title:
     ensure => $ensure,
@@ -47,7 +51,12 @@ define tsm::installpkg (
         install_options => ['-G', ],
         provider        => 'sun',
       }
-
+    }
+    'AIX': {
+      Package[$title] {
+        source   => $source,
+        provider => $provider,
+      }
     }
     default: {
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -28,68 +28,103 @@ class tsm::params {
   $comm_method         = 'TCPip'
   $tcp_port            = '1500'
 
-  $config              = '/opt/tivoli/tsm/client/ba/bin/dsm.sys'
-  $config_opt          = '/opt/tivoli/tsm/client/ba/bin/dsm.opt'
   $config_template     = 'tsm/dsm.sys.erb'
   $config_opt_template = 'tsm/dsm.opt.erb'
   $config_replace      = false
 
-  $inclexcl            = '/opt/tivoli/tsm/client/ba/bin/InclExcl'
-  $inclexcl_local      = '/opt/tivoli/tsm/client/ba/bin/InclExcl.local'
   $inclexcl_replace    = false
 
   case $::osfamily {
     redhat: {
       if $::operatingsystemmajrelease == '7' {
+        $config                = '/opt/tivoli/tsm/client/ba/bin/dsm.sys'
+        $config_opt            = '/opt/tivoli/tsm/client/ba/bin/dsm.opt'
+        $inclexcl              = '/opt/tivoli/tsm/client/ba/bin/InclExcl'
+        $inclexcl_local        = '/opt/tivoli/tsm/client/ba/bin/InclExcl.local'
         $packages              = ['TIVsm-BA']
         $service_name          = 'dsmsched'
         $service_script        = '/etc/systemd/system/dsmsched.service'
         $service_script_source = 'puppet:///modules/tsm/dsmsched.redhat7'
         $inclexcl_source       = 'puppet:///modules/tsm/InclExcl.redhat'
+        $rootgroup             = 'root'
       }
       else {
+        $config                = '/opt/tivoli/tsm/client/ba/bin/dsm.sys'
+        $config_opt            = '/opt/tivoli/tsm/client/ba/bin/dsm.opt'
+        $inclexcl              = '/opt/tivoli/tsm/client/ba/bin/InclExcl'
+        $inclexcl_local        = '/opt/tivoli/tsm/client/ba/bin/InclExcl.local'
         $packages              = ['TIVsm-BA']
         $service_name          = 'dsmsched'
         $service_script        = '/etc/init.d/dsmsched'
         $service_script_source = 'puppet:///modules/tsm/dsmsched.redhat'
         $inclexcl_source       = 'puppet:///modules/tsm/InclExcl.redhat'
+        $rootgroup             = 'root'
       }
     }
     debian: {
+      $config                = '/opt/tivoli/tsm/client/ba/bin/dsm.sys'
+      $config_opt            = '/opt/tivoli/tsm/client/ba/bin/dsm.opt'
+      $inclexcl              = '/opt/tivoli/tsm/client/ba/bin/InclExcl'
+      $inclexcl_local        = '/opt/tivoli/tsm/client/ba/bin/InclExcl.local'
       $packages              = ['tivsm-api64', 'tivsm-ba', 'gskcrypt64', 'gskssl64']
       $service_name          = 'dsmsched'
       $service_script        = '/etc/init.d/dsmsched'
       $service_script_source = 'puppet:///modules/tsm/dsmsched.debian'
       $inclexcl_source       = 'puppet:///modules/tsm/InclExcl.debian'
+      $rootgroup             = 'root'
     }
     solaris: {
       case $::hardwareisa {
         i386: {
+          $config                  = '/opt/tivoli/tsm/client/ba/bin/dsm.sys'
+          $config_opt              = '/opt/tivoli/tsm/client/ba/bin/dsm.opt'
+          $inclexcl                = '/opt/tivoli/tsm/client/ba/bin/InclExcl'
+          $inclexcl_local          = '/opt/tivoli/tsm/client/ba/bin/InclExcl.local'
           $packages                = ['gsk8cry32','gsk8cry64','gsk8ssl32','gsk8ssl64','TIVsmCapi', 'TIVsmCba']
           $package_uri             = "http://server/pkgs/solaris/${::hardwareisa}/5.10"
           $package_adminfile       = '/var/sadm/install/admin/puppet'
+          $package_provider        = 'sun'
           $service_name            = 'tsm'
           $service_manifest        = '/var/svc/manifest/site/tsmsched.xml'
           $service_manifest_source = 'puppet:///modules/tsm/tsmsched.xml'
           $service_script          = '/lib/svc/method/tsmsched'
           $service_script_source   = 'puppet:///modules/tsm/tsmsched.solaris'
           $inclexcl_source         = 'puppet:///modules/tsm/InclExcl.solaris'
+          $rootgroup               = 'root'
         }
         sparc: {
+          $config                  = '/opt/tivoli/tsm/client/ba/bin/dsm.sys'
+          $config_opt              = '/opt/tivoli/tsm/client/ba/bin/dsm.opt'
+          $inclexcl                = '/opt/tivoli/tsm/client/ba/bin/InclExcl'
+          $inclexcl_local          = '/opt/tivoli/tsm/client/ba/bin/InclExcl.local'
           $packages                = ['gsk8cry64','gsk8ssl64','TIVsmCapi', 'TIVsmCba']
           $package_uri             = "http://server/pkgs/solaris/${::hardwareisa}/5.10"
           $package_adminfile       = '/var/sadm/install/admin/puppet'
+          $package_provider        = 'sun'
           $service_name            = 'tsm'
           $service_manifest        = '/var/svc/manifest/site/tsmsched.xml'
           $service_manifest_source = 'puppet:///modules/tsm/tsmsched.xml'
           $service_script          = '/lib/svc/method/tsmsched'
           $service_script_source   = 'puppet:///modules/tsm/tsmsched.solaris'
           $inclexcl_source         = 'puppet:///modules/tsm/InclExcl.solaris'
+          $rootgroup               = 'root'
         }
         default:{
           fail("Unsupported hardwareisa ${::hardwareisa} for osfamily ${::osfamily} in config.pp!")
         }
       }
+    }
+    'AIX': {
+      $config           = '/usr/tivoli/tsm/client/ba/bin64/dsm.sys'
+      $config_opt       = '/usr/tivoli/tsm/client/ba/bin64/dsm.opt'
+      $inclexcl         = '/usr/tivoli/tsm/client/ba/bin64/InclExcl'
+      $inclexcl_local   = '/usr/tivoli/tsm/client/ba/bin64/InclExcl.local'
+      $packages         = ['tivoli.tsm.client.ba.64bit.base']
+      $package_provider = 'nim'
+      $package_source   = undef
+      $service_name     = 'dsmsched'
+      $inclexcl_source  = 'puppet:///modules/tsm/InclExcl.AIX'
+      $rootgroup        = 'system'
     }
     default: {
       fail("Unsupported osfamily ${::osfamily} in config.pp!")

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -36,6 +36,9 @@ class tsm::service inherits tsm {
       solaris: {
         include tsm::service::solaris
       }
+      'AIX': {
+        include tsm::service::aix
+      }
       default: {
         fail("Unsupported osfamily ${::osfamily} for managing the service!")
       }

--- a/manifests/service/aix.pp
+++ b/manifests/service/aix.pp
@@ -1,0 +1,22 @@
+# == Class: tsm::service::aix
+#
+# Manage tsm service on AIX
+#
+
+class tsm::service::aix {
+
+  exec { 'mkssys':
+    command => '/usr/bin/mkssys -s dsmsched -p /usr/bin/dsmc -u 0 -a "sched" -S -n 15 -f 9 -R -q',
+    unless  => "/usr/bin/lssrc -s ${::tsm::service_name}";
+  }
+
+  service { $::tsm::service_name:
+    ensure     => $::tsm::service_ensure,
+    enable     => $::tsm::service_enable,
+    hasstatus  => true,
+    hasrestart => false,
+    subscribe  => Concat[$::tsm::config],
+  }
+
+  Exec['mkssys'] -> Service[$::tsm::service_name]
+}

--- a/spec/classes/tsm_spec.rb
+++ b/spec/classes/tsm_spec.rb
@@ -89,6 +89,81 @@ describe 'tsm' do
         'mode'    => '0644'
       })
     end
+    
+    context 'on AIX' do
+   
+      let :facts do
+        {
+          :osfamily      => 'AIX',
+          :concat_basedir => '/dne',
+        }
+      end
+   
+      it do
+        should contain_concat('/usr/tivoli/tsm/client/ba/bin64/dsm.sys').with({
+          'ensure'  => 'present',
+          'replace' => false,
+          'owner'   => 'root',
+          'group'   => 'system',
+          'mode'    => '0644'
+        })
+      end
+   
+      it do
+        should contain_concat__fragment('dsm_sys_template').with({
+          'target' => '/usr/tivoli/tsm/client/ba/bin64/dsm.sys',
+        })
+      end
+   
+      it do
+        should contain_concat__fragment('dsm_sys_local').with({
+          'target' => '/usr/tivoli/tsm/client/ba/bin64/dsm.sys',
+          'source' => '/usr/tivoli/tsm/client/ba/bin64/dsm.sys.local',
+          'order'  => '02',
+        })
+      end
+   
+      it do
+        should contain_file('/usr/tivoli/tsm/client/ba/bin64/dsm.sys.local').with({
+          'ensure'  => 'file',
+          'owner'   => 'root',
+          'group'   => 'system',
+          'mode'    => '0644'
+        })
+      end
+   
+      it { should contain_concat__fragment('dsm_sys_local').that_requires('File[/usr/tivoli/tsm/client/ba/bin64/dsm.sys.local]') }
+   
+      it do
+        should contain_file('/usr/tivoli/tsm/client/ba/bin64/InclExcl').with({
+          'ensure'  => 'file',
+          'replace' => 'false',
+          'owner'   => 'root',
+          'group'   => 'system',
+          'mode'    => '0644'
+        })
+      end
+   
+      it do
+        should contain_file('/usr/tivoli/tsm/client/ba/bin64/InclExcl.local').with({
+          'ensure'  => 'file',
+          'replace' => 'false',
+          'owner'   => 'root',
+          'group'   => 'system',
+          'mode'    => '0644'
+        })
+      end
+   
+      it do
+        should_not contain_file('//usr/tivoli/tsm/client/ba/bin64/dsm.opt').with({
+          'ensure'  => 'file',
+          'replace' => 'false',
+          'owner'   => 'root',
+          'group'   => 'system',
+          'mode'    => '0644'
+        })
+      end
+    end
 
     context 'tsm::config with dsm.opt file' do
 
@@ -183,8 +258,28 @@ describe 'tsm' do
         })
       end
     end
-  end
 
+    context 'on AIX' do
+      let :facts do
+        {
+          :osfamily                  => 'AIX',
+          :concat_basedir            => '/dne',
+        }
+      end
+
+      it do
+        should contain_file('/usr/tivoli/tsm/client/ba/bin64/InclExcl').with({
+          'ensure'  => 'file',
+          'replace' => 'false',
+          'owner'   => 'root',
+          'group'   => 'system',
+          'mode'    => '0644',
+          'source'  => 'puppet:///modules/tsm/InclExcl.AIX'
+        })
+      end
+    end
+    
+  end
 
   context 'tsm::config with config_replace set to true' do
     let(:params) do
@@ -213,6 +308,42 @@ describe 'tsm' do
           'mode'    => '0644'
         })
       end
+    context 'on AIX' do
+
+      let :facts do
+        {
+          :osfamily                  => 'AIX',
+          :concat_basedir            => '/dne',
+        }
+      end
+        
+      let(:params) do
+        {
+          :tcp_server_address => 'tsm',
+          :config_replace => true,
+        }
+      end
+   
+      it do
+        should_not contain_file('/usr/tivoli/tsm/client/ba/bin64/dsm.opt').with({
+            'ensure'  => 'file',
+            'replace' => true,
+            'owner'   => 'root',
+            'group'   => 'system',
+            'mode'    => '0644'
+          })
+      end
+   
+      it do
+          should contain_concat('/usr/tivoli/tsm/client/ba/bin64/dsm.sys').with({
+            'ensure'  => 'present',
+            'replace' => true,
+            'owner'   => 'root',
+            'group'   => 'system',
+            'mode'    => '0644'
+          })
+      end
+    end
   end
 
   context 'tsm::install on RedHat 6' do
@@ -258,7 +389,6 @@ describe 'tsm' do
       it { should contain_tsm__installpkg("deadbeaf").with_ensure('installed') }
     end
   end
-
 
   context 'tsm::service on Redhat 6' do
     let :facts do
@@ -432,7 +562,7 @@ describe 'tsm' do
       {
         :osfamily                  => 'Debian',
         :operatingsystemmajrelease => '7',
-        :architecure               => 'amd64',
+        :architecture              => 'amd64',
         :concat_basedir            => '/dne',
       }
     end
@@ -616,4 +746,72 @@ describe 'tsm' do
       it { should contain_service('tsm').that_requires('Exec[generate-tsm.pwd]') }
     end
   end
+
+  context 'tsm::install on AIX' do
+    let :facts do
+      {
+        :osfamily                  => 'AIX',
+        :concat_basedir            => '/dne',
+
+      }
+    end
+
+    describe 'when tsm::service_manage is false' do
+      it { should_not contain_class('tsm::service::aix')}
+    end
+
+    describe 'should install tsm packages ' do
+      let(:params) do
+        {
+          :tcp_server_address => 'tsm',
+        }
+      end
+
+      it { should contain_tsm__installpkg('tivoli.tsm.client.ba.64bit.base').with_ensure('installed') }
+    end
+  end
+
+  context 'tsm::service on AIX' do
+    let :facts do
+      {
+        :osfamily                  => 'AIX',
+        :concat_basedir            => '/dne',
+      }
+    end
+
+    describe 'when tsm::service_manage is false' do
+      it { should_not contain_class('tsm::service::aix')}
+    end
+
+    describe 'when tsm::service_manage is true' do
+      let(:params) do
+        {
+          :tcp_server_address => 'tsm',
+          :service_manage     => true,
+        }
+      end
+
+      it { should contain_class('tsm::service::aix')}
+
+      it do
+        should contain_exec('mkssys').with({
+          'command'  => '/usr/bin/mkssys -s dsmsched -p /usr/bin/dsmc -u 0 -a "sched" -S -n 15 -f 9 -R -q',
+          'unless'   => '/usr/bin/lssrc -s dsmsched'
+        })
+      end
+
+      it do
+        should contain_service('dsmsched').with({
+          'ensure'     => 'running',
+          'enable'     => 'true',
+          'hasstatus'  => 'true',
+          'hasrestart' => 'false',
+          'subscribe'  => 'Concat[/usr/tivoli/tsm/client/ba/bin64/dsm.sys]',
+        })
+      end
+
+      it { should contain_service('dsmsched').that_requires('Exec[mkssys]') }
+    end
+  end
+
 end

--- a/spec/defines/installpkg_spec.rb
+++ b/spec/defines/installpkg_spec.rb
@@ -49,4 +49,17 @@ describe 'tsm::installpkg', :type => :define do
                                               })
     end
   end
+
+  context 'on AIX' do
+    let(:title) { 'tivoli.tsm.client.ba.64bit.base'}
+      
+    let :facts do
+    {
+      :osfamily => 'AIX'
+    }
+    end
+
+    it { should contain_package('tivoli.tsm.client.ba.64bit.base').with_ensure('installed') }
+  end
+
 end


### PR DESCRIPTION
Added $tsm::rootgroup and changed config.pp, because in a default AIX setup the "root" group is not available.
Added $tsm::package_provider and $tsm::package_source to make the TSM package intstallable via NIM which is set as default in this module.

Found a bug in manifests/service/debian.pp (and maybe other). Subscription in the service type should point to Concat[$::tsm::config] instead of File[$::tsm::config] in order to make the service restart after a configuration change. Patched it in manifests/service/aix.pp.