### PR TITLE
support arrays in config_opt_hash allowing for multiple DOMAIN entries in dsm.opt

### DIFF
--- a/spec/classes/tsm_spec.rb
+++ b/spec/classes/tsm_spec.rb
@@ -163,6 +163,7 @@ describe 'tsm' do
         'key1' => 'val1',
         'key2' => 'val2',
         'key3' => 'val3',
+        'key4' => [ 'val41', 'val42', ],
       }
 
       let(:params) {{
@@ -178,7 +179,15 @@ describe 'tsm' do
           })
 
         config_opt_hash.each do |k,v|
-          should contain_file('/opt/tivoli/tsm/client/ba/bin/dsm.opt').with_content(/#{k}\s+#{v}/)
+          if v.is_a?(String)
+            should contain_file('/opt/tivoli/tsm/client/ba/bin/dsm.opt').with_content(/#{k}\s+#{v}/)
+          elsif v.is_a?(Array)
+            v.each do |a|
+              should contain_file('/opt/tivoli/tsm/client/ba/bin/dsm.opt').with_content(/#{k}\s+#{a}/)
+            end
+          else
+            fail "value is neither String nor Array"
+          end
         end
       end
     end

--- a/templates/dsm.opt.erb
+++ b/templates/dsm.opt.erb
@@ -4,10 +4,17 @@
 
 <%- @config_opt_hash = scope['::tsm::config_opt_hash']%>
 
-<%- if not @config_opt_hash.nil? -%>
+<%- if ! @config_opt_hash.nil? -%>
 <%-   @config_opt_hash.keys.sort.each do |config_key| -%>
 <%-     config_value = @config_opt_hash[config_key] -%>
-<%-     line = "%-21s %s" % [config_key, config_value] -%>
+<%-     if config_value.kind_of?(Array) -%>
+<%-       config_value.each do |item| -%>
+<%-         line = "   %-21s %s" % [config_key, item] -%>
 <%=     line %>
+<%-       end -%>
+<%-     else -%>
+<%-       line = "   %-21s %s" % [config_key, config_value] -%>
+<%=     line %>
+<%-     end -%>
 <%-   end -%>
 <%- end -%>


### PR DESCRIPTION
Currently, it is not possible to have an array on the value side of config_opt_hash, as it is possible in config_hash. This prevents multiple DOMAIN lines to be written to dsm.opt which is necessary to have multiple filesystems backed up.

My patch

(1) introduces a test case which fails without the extended dsm.opt.erb (allowing verifiability of the patch)
(2) introduces code taken from dsm.sys.erb to dsb.opt.erb which handles arrays.

The test case succeeds if both patches are applied.

Unfortunately, the "old" test case succeeds with an array on the right hand side of an config_opt_hash with the old code since the array wil get stringified in both the template _and_ the test.

This is my first merge request on github and also my first rspec test, so both actions may be flawed.

Please consider merging and making a new release.

Greetings
Marc
