### PR TITLE
Dsmcad support. Fixes #18

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ The default dsm.sys template already includes the *InclExcl.local* file.
 
 If you want to use the Client Acceptor Daemon (dsmcad) instead of the Scheduler (dsmsched),
 you have to overwrite the following variables.
+
 Example for RedHat 7:
 
     tsm::service_script: "/etc/systemd/system/dsmcad.service"

--- a/README.md
+++ b/README.md
@@ -161,6 +161,17 @@ In the case of a puppet managed include/exclude file, you can add
 local include/exclude rules to
 */opt/tivoli/tsm/clien/ba/bin/InclExcl.local*
 The default dsm.sys template already includes the *InclExcl.local* file.
+
+### Using the Client Acceptor Daemon (dsmcad)
+
+If you want to use the Client Acceptor Daemon (dsmcad) instead of the Scheduler (dsmsched),
+you have to overwrite the following variables.
+Example for RedHat 7:
+
+    tsm::service_script: "/etc/systemd/system/dsmcad.service"
+    tsm::service_name: "dsmcad"
+    tsm::service_script_source: 'puppet:///modules/tsm/dsmcad.redhat7'
+
 ##Reference
 
 Please see [init.pp](manifests/init.pp) for an explanation of all available options.

--- a/files/dsmcad.debian
+++ b/files/dsmcad.debian
@@ -1,0 +1,62 @@
+#!/bin/bash
+#
+### BEGIN INIT INFO
+# Provides:             dsmcad
+# Required-Start:       $local_fs $remote_fs $syslog networking
+# Required-Stop:
+# Default-Start:        2 3 4 5
+# Default-Stop:         0 1 6
+# Short-Description:    dsmcad
+# Description:          IBM Tivoli Backup Client
+### END INIT INFO
+#
+
+# PATH=${PATH}:/usr/adsm:/usr/local/sbin
+# export PATH
+export LANG=is_IS
+DSM_DIR=/opt/tivoli/tsm/client/ba/bin
+DSM_CONFIG=/opt/tivoli/tsm/client/ba/bin/dsm.opt
+export DSM_DIR DSM_CONFIG
+linke=`ls -d /opt/tivoli/tsm/client/ba/bin/is_IS`
+if test "$linke"
+then
+        sleep 0
+else
+        ln -s /opt/tivoli/tsm/client/ba/bin/en_US /opt/tivoli/tsm/client/ba/bin/is_IS
+fi
+# See how we were called.
+case "$1" in
+  start)
+        echo -n "Starting dsmcad. "
+        dsmc sch -RunAsService > /dev/null 2>&1 &
+        echo
+        ;;
+  stop)
+        echo -n "Stopping dsmcad: "
+        pid=`/bin/ps ax | /bin/grep -w dsmc | /bin/grep -v grep | /bin/grep -v dsmcad | /usr/bin/awk '{print $1}'`
+        if test "$pid"
+        then
+                kill $pid
+        echo
+        fi
+        ;;
+  restart)
+        $0 stop
+        $0 start
+        ;;
+  status)
+        pid=`/bin/ps ax | /bin/grep -w dsmc | /bin/grep -v grep | /bin/grep -v dsmcad | /usr/bin/awk '{print $1}'`
+        if test "$pid"
+        then
+                echo "dsmcad is running with PID: "$pid
+        else
+                echo "dsmcad is not running "
+                exit 1
+        fi
+        ;;
+  *)
+        echo "Usage: dsmcad {start|stop|restart|status}"
+        exit 1
+esac
+
+exit 0

--- a/files/dsmcad.redhat
+++ b/files/dsmcad.redhat
@@ -1,52 +1,168 @@
-#!/bin/bash
+#!/bin/sh
 #
-# chkconfig: 345 99 99
-# description: starts the tsm Client Acceptor Daemon at system boot
-# config:
-# pidfile:
+# (C) Copyright IBM Corporation 2011
 #
-prog="/opt/tivoli/tsm/client/ba/bin/dsmcad"
+# chkconfig: 35 95 5
+# description: TSM Client Acceptor Daemon
+#
+### BEGIN INIT INFO
+# Provides: dsmcad
+# Required-Start: $local_fs $remote_fs $network
+# Required-Stop:
+# Default-Start: 3 5
+# Default-Stop: 0 1 2 6
+# Short-Description: TSM Client Acceptor Daemon
+# Description: Start dsmcad to enable scheduler and Web GUI.
+### END INIT INFO
 
-[ ! -x "$prog" ] && exit 0
+DSMCAD_DIR=/opt/tivoli/tsm/client/ba/bin
+DSMCAD_BIN=$DSMCAD_DIR/dsmcad
+if [ ! -x $DSMCAD_BIN ]
+then
+   echo "$DSMCAD_BIN is not installed"
+   if [ "$1" = "stop" ]
+   then
+      exit 0
+   else
+      exit 5
+   fi
+fi
 
-# Source function library.
-. /etc/rc.d/init.d/functions
+if [ -f /etc/redhat-release ]
+then
+   . /etc/init.d/functions
+
+   start_()
+   {
+      echo -n "Starting dsmcad:"
+      cd $DSMCAD_DIR
+      daemon $DSMCAD_BIN
+      echo
+   }
+
+   stop_()
+   {
+      echo -n "Stopping dsmcad:"
+      killproc -d 10 dsmcad
+      echo
+      return $?
+   }
+
+   status_()
+   {
+      status dsmcad
+   }
+
+elif [ -f /etc/SuSE-release ]
+then
+   . /etc/rc.status
+
+   rc_reset
+
+   export LANG=en_US.UTF-8
+   export LC_ALL=en_US.UTF-8
+
+   start_()
+   {
+      echo -n "Starting dsmcad:"
+      cd $DSMCAD_DIR
+      startproc $DSMCAD_BIN
+      rc_status -v
+   }
+
+   stop_()
+   {
+      echo -n "Stopping dsmcad:"
+      killproc $DSMCAD_BIN
+      rc_status -v
+   }
+
+   status_()
+   {
+      echo -n "Checking dsmcad:"
+      checkproc $DSMCAD_BIN
+      rc_status -v
+   }
+
+elif [ -f /etc/os-release ]
+then
+   . /etc/os-release
+
+   if [ $NAME = "Ubuntu" ]
+   then
+
+      start_()
+      {
+         cd $DSMCAD_DIR
+         if start-stop-daemon --status --exec $DSMCAD_BIN
+         then
+            echo "dsmcad is already running, pid" `pidof $DSMCAD_BIN`
+         else
+            if start-stop-daemon --start --exec $DSMCAD_BIN
+            then
+               echo "dsmcad is started, pid" `pidof $DSMCAD_BIN`
+            else
+               echo "dsmcad could not be started"
+            fi
+         fi
+      }
+
+      stop_()
+      {
+         if start-stop-daemon --status --exec $DSMCAD_BIN
+         then
+            if start-stop-daemon --stop --exec $DSMCAD_BIN
+            then
+               echo "dsmcad is stopped"
+            else
+               echo "dsmcad could not be stopped"
+            fi
+         else
+            echo "dsmcad is not running"
+         fi
+      }
+
+      status_()
+      {
+         if start-stop-daemon --status --exec $DSMCAD_BIN
+         then
+            echo "dsmcad is running, pid" `pidof $DSMCAD_BIN`
+         else
+            echo "dsmcad is not running"
+         fi
+      }
+
+   fi
+
+else
+   echo "This distribution is not supported"
+   exit 2
+fi
+
+
 
 case "$1" in
-'start')
-        PID=`pidofproc dsmcad`
-        if [ "$PID" != "" ]; then
-                echo 'tsm scheduler already running.'
-                exit 1
-        fi
-        echo -n "Starting dsmc"
-        if [ -x /opt/tivoli/tsm/client/ba/bin/dsmcad ]; then
-                /opt/tivoli/tsm/client/ba/bin/dsmcad \
-                > /var/log/dsmc.out 2>&1 &
-                echo_success Starting dsmcad
-                echo
-        else
-                echo_failure
-                exit 1
-        fi
-        ;;
+   start)
+      start_
+   ;;
 
-'stop')
-        killproc $prog
-        echo "Stopping dsmcad"
-        ;;
+   stop)
+      stop_
+   ;;
 
-'restart')
-        $0 stop
-        $0 start
-        ;;
+   restart)
+      stop_
+      sleep 2
+      start_
+   ;;
 
-'status')
-        status $prog
-        ;;
+   status)
+      status_
+   ;;
 
-*)
-        echo "Usage: $0 { start | stop }"
-        exit 1
-        ;;
+   *)
+      echo "Usage: $0 {start|stop|restart|status}"
+      exit 1
+   ;;
 esac
+

--- a/files/dsmcad.redhat
+++ b/files/dsmcad.redhat
@@ -1,0 +1,52 @@
+#!/bin/bash
+#
+# chkconfig: 345 99 99
+# description: starts the tsm Client Acceptor Daemon at system boot
+# config:
+# pidfile:
+#
+prog="/opt/tivoli/tsm/client/ba/bin/dsmcad"
+
+[ ! -x "$prog" ] && exit 0
+
+# Source function library.
+. /etc/rc.d/init.d/functions
+
+case "$1" in
+'start')
+        PID=`pidofproc dsmcad`
+        if [ "$PID" != "" ]; then
+                echo 'tsm scheduler already running.'
+                exit 1
+        fi
+        echo -n "Starting dsmc"
+        if [ -x /opt/tivoli/tsm/client/ba/bin/dsmcad ]; then
+                /opt/tivoli/tsm/client/ba/bin/dsmcad \
+                > /var/log/dsmc.out 2>&1 &
+                echo_success Starting dsmcad
+                echo
+        else
+                echo_failure
+                exit 1
+        fi
+        ;;
+
+'stop')
+        killproc $prog
+        echo "Stopping dsmcad"
+        ;;
+
+'restart')
+        $0 stop
+        $0 start
+        ;;
+
+'status')
+        status $prog
+        ;;
+
+*)
+        echo "Usage: $0 { start | stop }"
+        exit 1
+        ;;
+esac

--- a/files/dsmcad.redhat7
+++ b/files/dsmcad.redhat7
@@ -1,0 +1,14 @@
+[Unit]
+Description=IBM Tivoli Storage Manager Client dsmcad systemd-style sample service description
+Documentation=http://www-01.ibm.com/support/knowledgecenter/SSGSG7_7.1.4/client/t_protect_wf.html?lang=en
+After=local-fs.target network-online.target
+
+[Service]
+Type=forking
+GuessMainPID=no
+Environment="DSM_LOG=/opt/tivoli/tsm/client/ba/bin" "LD_LIBRARY_PATH=/opt/tivoli/tsm/client/ba/bin"
+ExecStart=/opt/tivoli/tsm/client/ba/bin/dsmcad
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/files/tsmcad.solaris
+++ b/files/tsmcad.solaris
@@ -1,0 +1,65 @@
+#!/sbin/sh
+#
+#tm 01.10.2001 bsd teufel austreiben. sysv rules.
+#be 04.12.2006 bisschen angepasst fuer solaris smf
+#ts 11.06.2014 ja, wir verwenden auch zonen...
+#sg 03.08.2016 dsmcad
+##################################################
+
+getpid()
+{
+    PID=""
+    ZONENAME=`zonename`
+    PID=`pgrep -z $ZONENAME -f 'dsmcad'`
+}
+
+cad_start()
+{
+    getpid
+
+    if [ "$PID" !=  "" ]; then
+        echo "tsm cad already running (pid $PID)."
+        exit 1
+    fi
+    if [ -x /opt/tivoli/tsm/client/ba/bin/dsmcad ]; then
+        echo 'starting tsm cad.'
+        /opt/tivoli/tsm/client/ba/bin/dsmcad \
+            > /var/log/tsmcad.out 2>&1 &
+    else
+        echo 'cant find tsm executable!'
+        exit 1
+    fi
+}
+
+cad_stop()
+{
+    getpid
+
+    if [ "$PID" = "" ]; then
+        echo 'tsm cad not running.'
+        #exit 1
+    else
+        echo 'stopping tsm cad.'
+        [ "$PID" -gt 0 ] && kill -15 $PID
+    fi
+}
+
+case "$1" in
+    'start')
+        cad_start
+        ;;
+    'restart')
+        cad_stop
+        sleep 3 #wichtig
+        cad_start
+        ;;
+    'stop')
+        cad_stop
+        ;;
+    *)
+        echo "Usage: $0 { start | restart | stop }"
+        exit 1
+        ;;
+esac
+
+exit 0

--- a/files/tsmcad.xml
+++ b/files/tsmcad.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+<service_bundle type='manifest' name='OSS:tsmcad'>
+
+<service
+        name='network/tsm'
+        type='service'
+        version='1'>
+
+        <create_default_instance enabled='false' />
+
+        <single_instance />
+
+        <dependency name='fs-local'
+                grouping='require_all'
+                restart_on='none'
+                type='service'>
+                <service_fmri
+                        value='svc:/system/filesystem/local' />
+        </dependency>
+
+        <dependency name='net-loopback'
+                grouping='require_all'
+                restart_on='none'
+                type='service'>
+                <service_fmri value='svc:/network/loopback' />
+        </dependency>
+
+        <dependency name='net-physical'
+                grouping='require_all'
+                restart_on='none'
+                type='service'>
+                <service_fmri value='svc:/network/physical' />
+        </dependency>
+
+        <dependency name='config_data_sys'
+                grouping='require_all'
+                restart_on='restart'
+                type='path'>
+                <service_fmri
+                    value='file://localhost/opt/tivoli/tsm/client/ba/bin/dsm.sys' />
+        </dependency>
+
+        <dependency name='config_data_opt'
+                grouping='require_all'
+                restart_on='restart'
+                type='path'>
+                <service_fmri
+                    value='file://localhost/opt/tivoli/tsm/client/ba/bin/dsm.opt' />
+        </dependency>
+
+<!--
+        <dependent
+                name='ssh_multi-user-server'
+                grouping='optional_all'
+                restart_on='none'>
+                        <service_fmri
+                            value='svc:/milestone/multi-user-server' />
+        </dependent>
+-->
+        <exec_method
+                type='method'
+                name='start'
+                exec='/lib/svc/method/tsmcad start'
+                timeout_seconds='60'/>
+
+        <exec_method
+                type='method'
+                name='stop'
+                exec=':kill'
+                timeout_seconds='60' />
+
+        <exec_method
+                type='method'
+                name='refresh'
+                exec='/lib/svc/method/tsmcad restart'
+                timeout_seconds='60' />
+
+        <property_group name='startd'
+                type='framework'>
+                <!-- sub-process core dumps shouldn't restart session -->
+                <propval name='ignore_error'
+                    type='astring' value='core,signal' />
+        </property_group>
+
+        <property_group name='general' type='framework'>
+                <!-- to start stop sshd -->
+                <propval name='action_authorization' type='astring'
+                        value='solaris.smf.manage.ssh' />
+        </property_group>
+
+        <stability value='Unstable' />
+
+        <template>
+                <common_name>
+                        <loctext xml:lang='C'>
+                        TSM CAD
+                        </loctext>
+                </common_name>
+                <documentation>
+                        <manpage title='none' section='none' manpath='/usr/share/man' />
+                </documentation>
+        </template>
+
+</service>
+
+</service_bundle>

--- a/spec/classes/tsm_spec.rb
+++ b/spec/classes/tsm_spec.rb
@@ -450,6 +450,134 @@ describe 'tsm' do
 
     end
   end
+  context 'tsm::service::dsmcad on Redhat 6' do
+    let :facts do
+      {
+        :osfamily                  => 'RedHat',
+        :operatingsystemmajrelease => '6',
+        :architecure               => 'i386',
+        :concat_basedir            => '/dne',
+      }
+    end
+
+    describe 'when tsm::service_manage is false' do
+      it { should_not contain_class('tsm::service::redhat')}
+    end
+
+    describe 'when tsm::service_manage is true' do
+      let(:params) do
+        {
+          :tcp_server_address    => 'tsm',
+          :service_manage        => true,
+          :service_script        => '/etc/init.d/dsmcad',
+          :service_name          => 'dsmcad',
+          :service_script_source => 'puppet:///modules/tsm/dsmcad.redhat',
+
+        }
+      end
+
+      it { should contain_class('tsm::service::redhat')}
+
+      it do
+        should contain_file('/etc/init.d/dsmcad').with({
+          'ensure'  => 'file',
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0755',
+          'source'  => 'puppet:///modules/tsm/dsmcad.redhat'
+        })
+      end
+
+      it do
+        should contain_service('dsmcad').with({
+          'ensure'     => 'running',
+          'enable'     => 'true',
+          'hasstatus'  => 'true',
+          'hasrestart' => 'true',
+          'subscribe'  => 'Concat[/opt/tivoli/tsm/client/ba/bin/dsm.sys]',
+        })
+      end
+
+      it { should contain_service('dsmcad').that_requires('File[/etc/init.d/dsmcad]') }
+    end
+
+    describe 'when service_manage is true and set_intial_password is true' do
+      let(:params) do
+        {
+          :tcp_server_address    => 'tsm',
+          :service_manage        => true,
+          :initial_password      => 'start',
+          :set_initial_password  => true,
+          :service_script        => '/etc/init.d/dsmcad',
+          :service_name          => 'dsmcad',
+          :service_script_source => 'puppet:///modules/tsm/dsmcad.redhat',
+        }
+      end
+
+      it do
+        should contain_exec('generate-tsm.pwd').with({
+          'creates' => '/etc/adsm/TSM.PWD',
+          'path'    => ['/bin', '/usr/bin'],
+        })
+      end
+
+      it { should contain_exec('generate-tsm.pwd').with_command(/dsmc set password start .*/) }
+
+      it { should contain_service('dsmcad').that_requires('Exec[generate-tsm.pwd]') }
+
+    end
+  end
+
+
+  context 'tsm::service::dsmcad on Redhat 7' do
+    let :facts do
+      {
+        :osfamily                  => 'RedHat',
+        :operatingsystemmajrelease => '7',
+        :architecure               => 'i386',
+        :concat_basedir            => '/dne',
+        :service_script            => '/etc/systemd/system/dsmcad.service',
+        :service_name              => 'dsmcad',
+        :service_script_source     => 'puppet:///modules/tsm/dsmcad.redhat7',
+      }
+    end
+
+    describe 'when tsm::service_manage is true' do
+      let(:params) do
+        {
+          :tcp_server_address    => 'tsm',
+          :service_manage        => true,
+          :service_script        => '/etc/systemd/system/dsmcad.service',
+          :service_name          => 'dsmcad',
+          :service_script_source => 'puppet:///modules/tsm/dsmcad.redhat7',
+        }
+      end
+
+      it { should contain_class('tsm::service::redhat')}
+
+      it do
+        should contain_file('/etc/systemd/system/dsmcad.service').with({
+          'ensure'  => 'file',
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0644',
+          'source'  => 'puppet:///modules/tsm/dsmcad.redhat7'
+        })
+      end
+
+      it do
+        should contain_service('dsmcad').with({
+          'ensure'     => 'running',
+          'enable'     => 'true',
+          'hasstatus'  => 'true',
+          'hasrestart' => 'true',
+          'subscribe'  => 'Concat[/opt/tivoli/tsm/client/ba/bin/dsm.sys]',
+        })
+      end
+
+      it { should contain_service('dsmcad').that_requires('File[/etc/systemd/system/dsmcad.service]') }
+    end
+  end
 
   context 'tsm::service on Redhat 7' do
     let :facts do
@@ -594,6 +722,56 @@ describe 'tsm' do
       it { should contain_service('dsmsched').that_requires('File[/etc/init.d/dsmsched]') }
     end
   end
+  context 'tsm::service::dsmcad on Debian 7' do
+    let :facts do
+      {
+        :osfamily                  => 'Debian',
+        :operatingsystemmajrelease => '7',
+        :architecture              => 'amd64',
+        :concat_basedir            => '/dne',
+      }
+    end
+
+    describe 'when tsm::service_manage is false' do
+      it { should_not contain_class('tsm::service::debian')}
+    end
+
+    describe 'when tsm::service_manage is true' do
+      let(:params) do
+        {
+          :tcp_server_address    => 'tsm',
+          :service_manage        => true,
+          :service_script        => '/etc/init.d/dsmcad',
+          :service_name          => 'dsmcad',
+          :service_script_source => 'puppet:///modules/tsm/dsmcad.debian',
+        }
+      end
+
+      it { should contain_class('tsm::service::debian')}
+
+      it do
+        should contain_file('/etc/init.d/dsmcad').with({
+          'ensure'  => 'file',
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0755',
+          'source'  => 'puppet:///modules/tsm/dsmcad.debian'
+        })
+      end
+
+      it do
+        should contain_service('dsmcad').with({
+          'ensure'     => 'running',
+          'enable'     => 'true',
+          'hasstatus'  => 'true',
+          'hasrestart' => 'true',
+          'subscribe'  => 'Concat[/opt/tivoli/tsm/client/ba/bin/dsm.sys]',
+        })
+      end
+
+      it { should contain_service('dsmcad').that_requires('File[/etc/init.d/dsmcad]') }
+    end
+  end
 
   context 'tsm::install on Solaris 10 i386' do
     let :facts do
@@ -712,6 +890,92 @@ describe 'tsm' do
 
       it { should contain_service('tsm').that_requires('File[/var/svc/manifest/site/tsmsched.xml]') }
       it { should contain_service('tsm').that_requires('File[/lib/svc/method/tsmsched]') }
+    end
+
+    describe 'when service_manage is true and set_intial_password is true' do
+      let(:params) do
+        {
+          :tcp_server_address   => 'tsm',
+          :service_manage       => true,
+          :initial_password     => 'start',
+          :set_initial_password => true,
+        }
+      end
+
+      it do
+        should contain_exec('generate-tsm.pwd').with({
+          'creates' => '/etc/adsm/TSM.PWD',
+          'path'    => ['/bin', '/usr/bin'],
+        })
+      end
+
+      it { should contain_exec('generate-tsm.pwd').with_command(/dsmc set password start .*/) }
+
+      it { should contain_service('tsm').that_requires('Exec[generate-tsm.pwd]') }
+    end
+  end
+
+  context 'tsm::service::dsmcad on Solaris 10' do
+    let :facts do
+      {
+        :osfamily       => 'Solaris',
+        :kernelrelease  => '5.10',
+        :hardwareisa    => 'i386',
+        :concat_basedir => '/dne',
+      }
+    end
+
+    describe 'when tsm::service_manage is false' do
+      it { should_not contain_class('tsm::service::solaris')}
+    end
+
+    describe 'when tsm::service_manage is true' do
+      let(:params) do
+        {
+          :tcp_server_address      => 'tsm',
+          :service_manage          => true,
+          :service_manifest        => '/var/svc/manifest/site/tsmcad.xml',
+          :service_manifest_source => 'puppet:///modules/tsm/tsmcad.xml',
+          :service_script          => '/lib/svc/method/tsmcad',
+          :service_name            => 'tsm',
+          :service_script_source   => 'puppet:///modules/tsm/tsmcad.solaris',
+        }
+      end
+
+      it { should contain_class('tsm::service::solaris')}
+
+      it do
+        should contain_file('/lib/svc/method/tsmcad').with({
+          'ensure'  => 'file',
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0755',
+          'replace' => 'true',
+          'source'  => 'puppet:///modules/tsm/tsmcad.solaris'
+        })
+      end
+
+      it do
+        should contain_file('/var/svc/manifest/site/tsmcad.xml').with({
+          'ensure'  => 'file',
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0444',
+          'source'  => 'puppet:///modules/tsm/tsmcad.xml'
+        })
+      end
+
+      it do
+        should contain_service('tsm').with({
+          'ensure'    => 'running',
+          'enable'    => 'true',
+          'manifest'  => '/var/svc/manifest/site/tsmcad.xml',
+          'subscribe' => 'Concat[/opt/tivoli/tsm/client/ba/bin/dsm.sys]',
+        })
+      end
+
+      it { should contain_service('tsm').that_requires('File[/var/svc/manifest/site/tsmcad.xml]') }
+      it { should contain_service('tsm').that_requires('File[/lib/svc/method/tsmcad]') }
     end
 
     describe 'when service_manage is true and set_intial_password is true' do


### PR DESCRIPTION
This PR adds support for managing dsmcad as a service, instead of dsmsched.
Usage is fairly simple and not advanced. To use dsmcad, 3 variables have to be overwritten, as stated in the readme.

I tested it on Centos 7 personally, but could not test it on solaris or debian. I hope the travis-tests are good enough there.

For Solaris I just replaced tsmsched with tsmcad, hopefully that's enough. Same for the test, I copied them and replaced dsmsched with dsmcad.

This should be backwards-compatible and not break anything.