### PR TITLE
Bump concat version requirement

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,9 +2,9 @@ fixtures:
   forge_modules:
     stdlib:
       repo: puppetlabs-stdlib
-      ref: 4.11.0
+      ref: 4.25.1
     concat:
       repo: puppetlabs-concat
-      ref: 2.1.0
+      ref: 5.1.0
   symlinks:
     "tsm": "#{source_dir}"

--- a/metadata.json
+++ b/metadata.json
@@ -79,7 +79,7 @@
     },
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">=1.1.0 <3.0.0"
+      "version_requirement": ">=1.1.0 <6.0.0"
     }
   ]
 }


### PR DESCRIPTION
This raises the puppetlabs-concat module compatibility to < 6.0.0. All tests pass using concat 5.1.0.