### PR TITLE
added support for GSKit keystore password database

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -94,6 +94,11 @@
 #   config - optional
 #   Default: /etc/adsm/TSM.PWD
 #
+# [*tsm_pwd_kdb*]
+#   Path to the TSM GSKit password file used since 7.1.8
+#   config - optional
+#   Default: /etc/adsm/TSM.KDB
+#
 # [*initial_password*]
 #   First time password for connecting to the tsm server
 #   config - optional
@@ -250,6 +255,7 @@ class tsm (
   $service_script          = $::tsm::params::service_script,
   $service_script_source   = $::tsm::params::service_script_source,
   $tsm_pwd                 = $::tsm::params::tsm_pwd,
+  $tsm_pwd_kdb             = $::tsm::params::tsm_pwd_kdb,
   $initial_password        = $::tsm::params::initial_password,
   $set_initial_password    = $::tsm::params::set_initial_password,
   $config_dir              = $::tsm::params::config_dir,
@@ -281,6 +287,7 @@ class tsm (
   validate_bool($service_enable)
   validate_string($service_name)
   validate_absolute_path($tsm_pwd)
+  validate_absolute_path($tsm_pwd_kdb)
   validate_string($initial_password)
   validate_bool($set_initial_password)
   validate_absolute_path($config)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,6 +21,7 @@ class tsm::params {
 
   # default password file
   $tsm_pwd              = '/etc/adsm/TSM.PWD'
+  $tsm_pwd_kdb          = '/etc/adsm/TSM.KDB'
   $initial_password     = 'start'
   $set_initial_password = true
 

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -52,7 +52,7 @@ class tsm::service {
 
       exec {'generate-tsm.pwd':
         command => "dsmc set password ${::tsm::initial_password} ${password}",
-        creates => $::tsm::tsm_pwd,
+        unless  => ["test -f ${::tsm::tsm_pwd}", "test -f ${::tsm::tsm_pwd_kdb}"],
         path    => ['/bin', '/usr/bin']
       }
       Exec['generate-tsm.pwd'] -> Service[$::tsm::service_name]

--- a/spec/classes/tsm_spec.rb
+++ b/spec/classes/tsm_spec.rb
@@ -472,7 +472,7 @@ describe 'tsm' do
 
       it do
         should contain_exec('generate-tsm.pwd').with({
-          'creates' => '/etc/adsm/TSM.PWD',
+          'unless'  => ['test -f /etc/adsm/TSM.PWD', 'test -f /etc/adsm/TSM.KDB'],
           'path'    => ['/bin', '/usr/bin'],
         })
       end
@@ -549,7 +549,7 @@ describe 'tsm' do
 
       it do
         should contain_exec('generate-tsm.pwd').with({
-          'creates' => '/etc/adsm/TSM.PWD',
+          'unless'  => ['test -f /etc/adsm/TSM.PWD', 'test -f /etc/adsm/TSM.KDB'],
           'path'    => ['/bin', '/usr/bin'],
         })
       end
@@ -937,7 +937,7 @@ describe 'tsm' do
 
       it do
         should contain_exec('generate-tsm.pwd').with({
-          'creates' => '/etc/adsm/TSM.PWD',
+          'unless'  => ['test -f /etc/adsm/TSM.PWD', 'test -f /etc/adsm/TSM.KDB'],
           'path'    => ['/bin', '/usr/bin'],
         })
       end
@@ -1023,7 +1023,7 @@ describe 'tsm' do
 
       it do
         should contain_exec('generate-tsm.pwd').with({
-          'creates' => '/etc/adsm/TSM.PWD',
+          'unless'  => ['test -f /etc/adsm/TSM.PWD', 'test -f /etc/adsm/TSM.KDB'],
           'path'    => ['/bin', '/usr/bin'],
         })
       end


### PR DESCRIPTION
IBM changed the password database file name in tsm 7.1.8. I modified the module, to work with old and new versions.